### PR TITLE
fix(bio block): fixed ease-in-out

### DIFF
--- a/_patterns/00-styleguide/animations/01-transitions/_transitions.scss
+++ b/_patterns/00-styleguide/animations/01-transitions/_transitions.scss
@@ -1,14 +1,14 @@
 $trans-opacity__time: 0.3s;
-$trans-opacity__function: ease-in-out;
+$trans-opacity__function: cubic-bezier(0.645, 0.045, 0.355, 1);
 /// @example
 ///   transition: opacity $trans-opacity;
 $trans-opacity: $trans-opacity__time $trans-opacity__function; // convenience variable for using both
 
 $trans-move__time: 0.3s;
-$trans-move__function: ease-in-out;
+$trans-move__function: cubic-bezier(0.645, 0.045, 0.355, 1);
 /// @example
 ///   transition: left $trans-move;
-$trans-move: $trans-opacity__time $trans-move__function; // convenience variable for using both
+$trans-move: $trans-move__time $trans-move__function; // convenience variable for using both
 
 .demo-transition {
   &.transition-opacity {

--- a/_patterns/00-styleguide/animations/01-transitions/transitions.json
+++ b/_patterns/00-styleguide/animations/01-transitions/transitions.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "$trans-opacity__function",
-      "value": "ease-in-out",
+      "value": "cubic-bezier(0.645, 0.045, 0.355, 1)",
       "comment": ""
     },
     {
@@ -22,12 +22,12 @@
     },
     {
       "name": "$trans-move__function",
-      "value": "ease-in-out",
+      "value": "cubic-bezier(0.645, 0.045, 0.355, 1)",
       "comment": ""
     },
     {
       "name": "$trans-move",
-      "value": "$trans-opacity__time $trans-move__function",
+      "value": "$trans-move__time $trans-move__function",
       "comment": "convenience variable for using both"
     }
   ],

--- a/_patterns/03-components/bio-block/_bio-block.scss
+++ b/_patterns/03-components/bio-block/_bio-block.scss
@@ -3,10 +3,12 @@
   flex-direction: column;
   height: 100%;
   max-width: 350px;
+  transition: all $trans-opacity;
   &__image {
     height: 400px;
     background-size: cover;
     background-position: top center;
+    transition: filter $trans-opacity;
     @include breakpoint($bp--medium){
       filter: grayscale(100%);
     }
@@ -28,10 +30,8 @@
     }
   }
   &:hover {
-    transition: all $trans-opacity;
     transform: scale(1.01);
     .bio-block__image {
-      transition: filter $trans-opacity;
       filter: none;
     }
   }


### PR DESCRIPTION
The transition value was in the :hover block instead of the element itself. I also changed the ease-in-out keyword to the the cubic bezier equivalent, sometimes the keywords get messed up if there's too many variable layers between declaration and use.